### PR TITLE
Set loader utils to ^2.0.0, since latest loader-utils 3.0 version has error.

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "prepublish": "npm test"
   },
   "dependencies": {
-    "loader-utils": "*"
+    "loader-utils": "^2.0.0"
   },
   "keywords": [
     "webpack",


### PR DESCRIPTION
The error is: 

Syntax Error: TypeError: loaderUtils.getOptions is not a function